### PR TITLE
Exclude relnotes-tracking-issue from needs-triage

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -395,6 +395,7 @@ new_issue = true
 exclude_labels = [
     "C-tracking-issue",
     "A-diagnostics",
+    "relnotes-tracking-issue",
 ]
 
 [autolabel."WG-trait-system-refactor"]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
